### PR TITLE
feat: add one click install bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ To start the CLI tool, simply run:
 go run main.go
 ```
 
+## OR, run the one-click install command ! 
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/nexusrex18/lumine/main/install.sh | bash
+```
+
 The program will prompt you to select the services you want to configure. Follow the interactive menu to:
 
 - Set up CI/CD

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+installLumine() {
+    echo "Installing Lumine..."
+
+    INSTALL_DIR="/usr/local/bin"
+    TEMP_DIR="/tmp/lumine"
+
+    if ! command -v git &> /dev/null; then
+        echo "Git is not installed. Please install Git and try again."
+        exit 1
+    fi
+
+    if ! command -v go &> /dev/null; then
+        echo "Go (Golang) is not installed. Please install Go and try again."
+        exit 1
+    fi
+
+    echo "Cloning Lumine repository..."
+    git clone https://github.com/nexusrex18/lumine.git "$TEMP_DIR" || {
+        echo "Failed to clone the Lumine repository."
+        exit 1
+    }
+
+    cd "$TEMP_DIR" || exit
+
+    echo "Building Lumine CLI..."
+    go build -o lumine main.go || {
+        echo "Failed to build Lumine CLI."
+        exit 1
+    }
+
+    echo "Moving Lumine binary to $INSTALL_DIR..."
+    sudo mv lumine "$INSTALL_DIR/lumine" || {
+        echo "Failed to move Lumine CLI to $INSTALL_DIR. Please check your permissions."
+        exit 1
+    }
+
+    echo "Cleaning up temporary files..."
+    rm -rf "$TEMP_DIR"
+
+    if command -v lumine &> /dev/null; then
+        echo "Lumine installed successfully! 🎉"
+        echo "You can now run Lumine using the command: lumine"
+    else
+        echo "Something went wrong during the installation. Please check the steps above."
+    fi
+}
+
+installLumine


### PR DESCRIPTION
This PR introduces a one-click install bash script for Lumine CLI, simplifying the setup process for users.  

### Changes Made  
1. Added Bash Script (`install.sh`):  
   - Automates the installation process:  
     - Clones the Lumine repository.  
     - Checks for required dependencies (e.g., Git, Go).  
     - Builds the Lumine CLI binary using `go build`.  
     - Moves the binary to `/usr/local/bin` for global access.  
     - Cleans up temporary files after installation.  
   - Provides informative messages for users during the process.  
   - Handles errors gracefully to ensure a smooth experience.  

2. Updated README:  
   - Added a clear installation section with a link to the bash script.  
   - Included instructions for executing the script in a single command.  

### Testing  
- Tested the script on various environments to ensure compatibility and error handling.  

### Why This Change?  
- To make Lumine CLI more accessible by removing manual setup steps.  
- Enhances usability for new users and contributors.  

### Preview  
- Users can now install Lumine CLI with:  
  ```bash  
  curl -sSL <script-link> | bash  
  ```  

### Checklist
- [x] Add the bash script to the repository.  
- [x] Update the README with installation instructions.  
- [x] Test script across Linux environments.  